### PR TITLE
feat: add php-serialize package for PHP serialization in JavaScript

### DIFF
--- a/common/routes.js
+++ b/common/routes.js
@@ -6,21 +6,32 @@ const sales = require("../modules/sejoli/sales/salesController");
 const account = require("../modules/account/accountController");
 const license = require("../modules/sejoli/license/licenseController");
 const subs = require("../modules/sejoli/subscription/subscriptionController");
+const checkout = require("../modules/sejoli/checkout/checkoutController");
 
 router.get("/", async (req, res) => {
   res.send("Welcome to Node Api");
-});
+}); 
 
 router.post("/login", account.login);
 router.get("/users", fn.otorisasi("admin"), sample.getData);
 router.post("/addData", fn.otorisasi(), sample.addData);
 router.patch("/updateData", fn.otorisasi(), sample.updateData);
 router.delete("/delData", fn.otorisasi(), sample.delData);
+
+// router orders for sales
 router.get("/get-orders", fn.otorisasi(), sales.getOrder);
 router.patch("/update-order-status", fn.otorisasi(), sales.updateOrderStatus);
+
+// router licenses
 router.get("/get-licenses", fn.otorisasi(), license.getLicense);
+
+// router subscriptions
 router.get("/get-subs", fn.otorisasi(), subs.getSubs);
 router.patch("/update-subs", fn.otorisasi(), subs.updateSubsStatus);
+
+// router checkout
+router.get("/get-ck", fn.otorisasi(), checkout.getCK);
+router.get("/get-cp", fn.otorisasi(), checkout.getCP);
 
 
 module.exports = router;

--- a/modules/sejoli/checkout/checkoutController.js
+++ b/modules/sejoli/checkout/checkoutController.js
@@ -1,9 +1,16 @@
 const m = require("./checkoutModel");
 const fn = require("../../../common/fn");
 
-exports.getOrder = async (req, res) => {
+exports.getCK = async (req, res) => {
   let dt = { err: false, msg: "", flow: [], code: 200 };
-  dt = await m.getOrder(dt);
+  dt = await m.getCK(dt);
+  console.log("dt ", dt);
+  res.status(dt.code).json(fn.setResponse(dt));
+};
+
+exports.getCP = async (req, res) => {
+  let dt = { err: false, msg: "", flow: [], code: 200 };
+  dt = await m.getCP(dt);
   console.log("dt ", dt);
   res.status(dt.code).json(fn.setResponse(dt));
 };

--- a/modules/sejoli/checkout/checkoutModel.js
+++ b/modules/sejoli/checkout/checkoutModel.js
@@ -1,17 +1,19 @@
 const fn = require('../../../common/fn');
+const unserialize = require("php-serialize").unserialize;
 
-exports.getOrder = async (dt) => {
-     if (dt.err) {dt.flow.push('❌ salesModel.js | bypass getOrder');return dt;}
-        dt.flow.push('➡️. salesModel.js | start getOrder');
+exports.getCK = async (dt) => {
+     if (dt.err) {dt.flow.push('❌ salesModel.js | bypass getCK');return dt;}
+        dt.flow.push('➡️. salesModel.js | start getCK');
 
         let rows=[];
         
         try {
             [rows] = await fn.db.query(`
-            SELECT o.*, u.display_name, u.user_email, p.post_title AS product_name
+            SELECT o.*, u.display_name, u.user_email, p.post_title AS product_name, c.*
             FROM wp_sejolisa_orders o
             JOIN wp_users u ON o.user_id = u.ID
             JOIN wp_posts p ON o.product_id = p.ID
+            JOIN wp_sejolisa_coupons c
         `);
         } catch (error) {
             dt.flow.push('❌ salesModel.js | Error querying database. '+error);
@@ -39,6 +41,53 @@ exports.getOrder = async (dt) => {
 
         return dt;
 }
+
+exports.getCP = async (dt) => {
+  if (dt.err) {
+    dt.flow.push("❌ salesModel.js | bypass getCP");
+    return dt;
+  }
+  dt.flow.push("➡️. salesModel.js | start getCP");
+
+  let rows = [];
+
+  try {
+    [rows] = await fn.db.query(`
+         SELECT c.*
+         FROM wp_sejolisa_coupons c
+     `);
+  } catch (error) {
+    dt.flow.push("❌ salesModel.js | Error querying database. " + error);
+    dt.err = true;
+    dt.code = 500;
+    return dt;
+  }
+
+  let arr = [];
+  if (rows && rows.length > 0) {
+    // console.log(`✅ salesModel.js | Ditemukan ${rows.length} data.`);
+    rows.forEach((row) => {
+      try {
+        const parsedDiscount = unserialize(row.discount);
+        row.discount = parsedDiscount;
+      } catch (e) {
+        row.discount = null;
+      }
+      arr.push(row);
+    });
+  } else {
+    dt.flow.push("❌ salesModel.js | Tidak ada data ditemukan di DB.");
+    dt.err = true;
+    dt.code = 404;
+    return dt;
+  }
+
+  dt.data = arr;
+  dt.flow.push("✅ salesModel.js | data orders found");
+  dt.err = false;
+
+  return dt;
+};
 
 exports.postCheckout = async (dt) => {
   const { product_id, quantity, username, email, phone, payment_gateway, status } = dt.req_body;

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "api_nodejs",
+  "name": "member-midone",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -672,6 +672,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/php-serialize": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/php-serialize/-/php-serialize-5.1.3.tgz",
+      "integrity": "sha512-p7zXX8xjGgddgP6byN+KmGKM0x6uoMZBRZteBa9LonqgrDV3LyMxUeGVX7RTFYwWaUAnTEsUWJfHI3N7eKvJgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {

--- a/node_modules/php-serialize/LICENSE.md
+++ b/node_modules/php-serialize/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Steel Brain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/node_modules/php-serialize/README.md
+++ b/node_modules/php-serialize/README.md
@@ -1,0 +1,63 @@
+# PHP-Serialize
+
+It also supports `Serializable` objects decode. Here's how you can use them.
+
+#### Installation
+
+```sh
+$ npm install php-serialize # If you're using npm
+$ yarn add php-serialize # If you're using Yarn
+```
+
+#### Usage
+
+```js
+import {serialize, unserialize} from 'php-serialize'
+
+class User {
+  constructor({ name, age }) {
+    this.name = name
+    this.age = age
+  }
+  serialize() {
+    return JSON.stringify({ name: this.name, age: this.age })
+  }
+  unserialize(rawData) {
+    const { name, age } = JSON.parse(rawData)
+    this.name = name
+    this.age = age
+  }
+}
+const steel = new User({ name: 'Steel Brain', age: 17 })
+const serialized = serialize(steel)
+const unserialized = unserialize(serialized, { User: User }) // Passing available classes
+console.log(unserialized instanceof User) // true
+
+const serializedForNamespace = serialize(steel, {
+  'MyApp\\User': User,
+})
+// ^ Above code will serialize User class to given name
+```
+
+#### API
+
+```js
+export function serialize(
+  item: any,
+  phpToJsScope: Object = {},
+  options: { encoding: 'utf8' | 'binary' } = { encoding: 'utf8' }
+): string
+export function unserialize(
+  item: string,
+  scope: Object = {},
+  options: { strict: boolean, encoding: 'utf8' | 'binary' } = { strict: false, encoding: 'utf8' }
+): any
+export function isSerialized(
+  item: any,
+  strict: false
+): boolean
+```
+
+#### License
+
+This project is licensed under the terms of MIT License. See the License file for more info.

--- a/node_modules/php-serialize/lib/cjs/helpers.js
+++ b/node_modules/php-serialize/lib/cjs/helpers.js
@@ -1,0 +1,46 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.invariant = exports.getClass = exports.getIncompleteClass = exports.isInteger = exports.getByteLength = exports.__PHP_Incomplete_Class = void 0;
+// eslint-disable-next-line camelcase,@typescript-eslint/class-name-casing
+var __PHP_Incomplete_Class = /** @class */ (function () {
+    function __PHP_Incomplete_Class(name) {
+        this.__PHP_Incomplete_Class_Name = name;
+    }
+    return __PHP_Incomplete_Class;
+}());
+exports.__PHP_Incomplete_Class = __PHP_Incomplete_Class;
+function getByteLength(contents, options) {
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.byteLength(contents, options.encoding);
+    }
+    return encodeURIComponent(contents).replace(/%[A-F\d]{2}/g, 'U').length;
+}
+exports.getByteLength = getByteLength;
+// isInteger = is NOT a float but still a number
+function isInteger(value) {
+    return typeof value === 'number' && Number.parseInt(value.toString(), 10) === value;
+}
+exports.isInteger = isInteger;
+function getIncompleteClass(name) {
+    return new __PHP_Incomplete_Class(name);
+}
+exports.getIncompleteClass = getIncompleteClass;
+function getClass(prototype) {
+    function PhpClass() {
+        // No Op
+    }
+    PhpClass.prototype = prototype;
+    return PhpClass;
+}
+exports.getClass = getClass;
+/**
+ * Ensures that the given {@link value} is truthy, throws an {@link Error} otherwise.
+ * @param value the value to check to be truthy.
+ * @param message the message of the {@link Error} if the value is falsy.
+ */
+function invariant(value, message) {
+    if (!value) {
+        throw new Error(message);
+    }
+}
+exports.invariant = invariant;

--- a/node_modules/php-serialize/lib/cjs/index.js
+++ b/node_modules/php-serialize/lib/cjs/index.js
@@ -1,0 +1,12 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isSerialized = exports.unserialize = exports.serialize = void 0;
+var unserialize_1 = __importDefault(require("./unserialize"));
+exports.unserialize = unserialize_1.default;
+var serialize_1 = __importDefault(require("./serialize"));
+exports.serialize = serialize_1.default;
+var isSerialized_1 = __importDefault(require("./isSerialized"));
+exports.isSerialized = isSerialized_1.default;

--- a/node_modules/php-serialize/lib/cjs/isSerialized.js
+++ b/node_modules/php-serialize/lib/cjs/isSerialized.js
@@ -1,0 +1,67 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Check value to find if it was serialized.
+ * @param { string } item - Value to check to see if was serialized.
+ * @param { boolean } strict - Whether to be strict about the end of the string. Default value: false
+ */
+function isSerialized(givenItem, strict) {
+    if (strict === void 0) { strict = false; }
+    if (typeof givenItem !== 'string') {
+        return false;
+    }
+    var item = givenItem.replace(/^(\s*)|(\s*)$/g, '');
+    if (item === 'N;') {
+        return true;
+    }
+    if (item.length < 4) {
+        return false;
+    }
+    if (item[1] !== ':') {
+        return false;
+    }
+    if (strict) {
+        var lastc = item.slice(-1);
+        if (lastc !== ';' && lastc !== '}') {
+            return false;
+        }
+    }
+    else {
+        var semicolon = item.indexOf(';');
+        var brace = item.indexOf('}');
+        // Either ; or } must exist.
+        if (semicolon === -1 && brace === -1) {
+            return false;
+        }
+        // But neither must be in the first X characters.
+        if (semicolon !== -1 && semicolon < 3) {
+            return false;
+        }
+        if (brace !== -1 && brace < 4) {
+            return false;
+        }
+    }
+    var token = item.slice(0, 1);
+    var end = strict ? '$' : '';
+    switch (token) {
+        case 's':
+        case 'a':
+        case 'O':
+            if (strict) {
+                if (item.substr(-2, 1) !== '"') {
+                    return false;
+                }
+            }
+            else if (item.indexOf('"') === -1) {
+                return false;
+            }
+            return item.match(new RegExp("^" + token + ":[0-9]+:", 's')) !== null;
+        case 'b':
+        case 'i':
+        case 'd':
+            return item.match(new RegExp("^" + token + ":[0-9.E+-]+;" + end)) !== null;
+        default:
+    }
+    return false;
+}
+exports.default = isSerialized;

--- a/node_modules/php-serialize/lib/cjs/parser.js
+++ b/node_modules/php-serialize/lib/cjs/parser.js
@@ -1,0 +1,91 @@
+"use strict";
+var __read = (this && this.__read) || function (o, n) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator];
+    if (!m) return o;
+    var i = m.call(o), r, ar = [], e;
+    try {
+        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+    }
+    catch (error) { e = { error: error }; }
+    finally {
+        try {
+            if (r && !r.done && (m = i["return"])) m.call(i);
+        }
+        finally { if (e) throw e.error; }
+    }
+    return ar;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var PARSER_TYPES = {
+    N: 'null',
+    i: 'int',
+    d: 'float',
+    b: 'boolean',
+    s: 'string',
+    a: 'array-object',
+    C: 'serializable-class',
+    O: 'notserializable-class',
+};
+var Parser = /** @class */ (function () {
+    function Parser(contents, index, options) {
+        this.contents = contents;
+        this.index = index;
+        this.options = options;
+    }
+    Parser.prototype.error = function (message) {
+        if (message === void 0) { message = 'Syntax Error'; }
+        return new Error(message + " at index " + this.index + " while unserializing payload");
+    };
+    Parser.prototype.advance = function (index) {
+        this.index += index;
+    };
+    Parser.prototype.readAhead = function (index) {
+        var contents = this.peekAhead(index);
+        this.index += index;
+        return contents;
+    };
+    Parser.prototype.readUntil = function (expected) {
+        var index = this.contents.indexOf(expected, this.index);
+        if (index === -1) {
+            throw this.error("Expected '" + expected + "'");
+        }
+        return this.readAhead(index - this.index);
+    };
+    Parser.prototype.peekAhead = function (index) {
+        return this.contents.toString(this.options.encoding, this.index, this.index + index);
+    };
+    Parser.prototype.seekExpected = function (contents) {
+        var slice = this.readAhead(contents.length);
+        if (slice !== contents) {
+            this.index -= contents.length;
+            throw this.error("Expected '" + contents + "'");
+        }
+    };
+    Parser.prototype.getType = function () {
+        var _a = __read(this.readAhead(2), 2), type = _a[0], ps = _a[1];
+        var parserType = PARSER_TYPES[type];
+        if (!parserType) {
+            throw this.error('Unknown type');
+        }
+        if (parserType === 'null' ? ps !== ';' : ps !== ':') {
+            throw this.error();
+        }
+        return parserType;
+    };
+    Parser.prototype.getLength = function () {
+        var length = Number.parseInt(this.readUntil(':'), 10);
+        if (Number.isNaN(length)) {
+            throw this.error();
+        }
+        return length;
+    };
+    Parser.prototype.getByLength = function (startSequence, endSequence, callback) {
+        var length = this.getLength();
+        this.seekExpected(":" + startSequence);
+        var result = callback(length);
+        this.seekExpected(endSequence);
+        return result;
+    };
+    return Parser;
+}());
+exports.default = Parser;

--- a/node_modules/php-serialize/lib/cjs/serialize.js
+++ b/node_modules/php-serialize/lib/cjs/serialize.js
@@ -1,0 +1,86 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __read = (this && this.__read) || function (o, n) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator];
+    if (!m) return o;
+    var i = m.call(o), r, ar = [], e;
+    try {
+        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+    }
+    catch (error) { e = { error: error }; }
+    finally {
+        try {
+            if (r && !r.done && (m = i["return"])) m.call(i);
+        }
+        finally { if (e) throw e.error; }
+    }
+    return ar;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var helpers_1 = require("./helpers");
+function getClassNamespace(item, scope) {
+    return (Object.keys(scope).find(function (key) { return item instanceof scope[key]; }) || item.__PHP_Incomplete_Class_Name || item.constructor.name);
+}
+function serializeObject(item, scope) {
+    var processed = Array.isArray(item)
+        ? item.map(function (value, index) { return "" + serialize(index, scope) + serialize(value, scope); })
+        : Object.keys(item).map(function (key) { return "" + serialize(key, scope) + serialize(item[key], scope); });
+    var length = processed.filter(function (entry) { return typeof entry !== 'undefined'; }).length;
+    return length + ":{" + processed.join('') + "}";
+}
+function serialize(item, scope, givenOptions) {
+    if (scope === void 0) { scope = {}; }
+    if (givenOptions === void 0) { givenOptions = {}; }
+    var type = typeof item;
+    var options = __assign({}, givenOptions);
+    if (typeof options.encoding === 'undefined') {
+        options.encoding = 'utf8';
+    }
+    if (item === null) {
+        return 'N;';
+    }
+    if (type === 'number' || type === 'bigint') {
+        if (typeof item === 'bigint' || helpers_1.isInteger(item)) {
+            return "i:" + item + ";";
+        }
+        return "d:" + item.toString().toUpperCase() + ";";
+    }
+    if (type === 'string') {
+        return "s:" + helpers_1.getByteLength(item, options) + ":\"" + item + "\";";
+    }
+    if (type === 'boolean') {
+        return "b:" + (item ? '1' : '0') + ";";
+    }
+    if (type !== 'object') {
+        throw new TypeError("Unexpected type '" + type + "' encountered while attempting to serialize");
+    }
+    if (Array.isArray(item) || item.constructor.name === 'Object') {
+        return "a:" + serializeObject(item, scope);
+    }
+    if (item instanceof Map) {
+        return "a:" + item.size + ":{" + Array.from(item.entries())
+            .map(function (_a) {
+            var _b = __read(_a, 2), key = _b[0], value = _b[1];
+            return "" + serialize(key, scope) + serialize(value, scope);
+        })
+            .join('') + "}";
+    }
+    var constructorName = getClassNamespace(item, scope);
+    if (typeof item.serialize === 'function') {
+        var serialized = item.serialize();
+        helpers_1.invariant(typeof serialized === 'string', item.constructor.name + ".serialize should return a string");
+        return "C:" + constructorName.length + ":\"" + constructorName + "\":" + helpers_1.getByteLength(serialized, options) + ":{" + serialized + "}";
+    }
+    return "O:" + constructorName.length + ":\"" + constructorName + "\":" + serializeObject(item, scope);
+}
+exports.default = serialize;

--- a/node_modules/php-serialize/lib/cjs/unserialize.js
+++ b/node_modules/php-serialize/lib/cjs/unserialize.js
@@ -1,0 +1,130 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// eslint-disable-next-line import/no-cycle
+var parser_1 = __importDefault(require("./parser"));
+var helpers_1 = require("./helpers");
+function getClassReference(className, scope, strict) {
+    var container;
+    var classReference = scope[className];
+    helpers_1.invariant(classReference || !strict, "Class " + className + " not found in given scope");
+    if (classReference) {
+        // @ts-ignore
+        container = new (helpers_1.getClass(classReference.prototype))();
+    }
+    else {
+        container = helpers_1.getIncompleteClass(className);
+    }
+    return container;
+}
+function unserializePairs(parser, length, scope, options) {
+    var pairs = [];
+    for (var i = 0; i < length; i += 1) {
+        var key = unserializeItem(parser, scope, options);
+        parser.seekExpected(';');
+        var value = unserializeItem(parser, scope, options);
+        if (parser.peekAhead(1) === ';') {
+            parser.advance(1);
+        }
+        pairs.push({ key: key, value: value });
+    }
+    return pairs;
+}
+function unserializeItem(parser, scope, options) {
+    var type = parser.getType();
+    if (type === 'null') {
+        return null;
+    }
+    if (type === 'int' || type === 'float') {
+        var value = parser.readUntil(';');
+        var parsedValue = type === 'int' ? parseInt(value, 10) : parseFloat(value);
+        if (parsedValue.toString() !== value) {
+            if (!value.includes('.')) {
+                parsedValue = BigInt(value); // Only convert to BigInt if there's no decimal
+            }
+            else {
+                parsedValue = parseFloat(value); // Ensure floats remain as float
+            }
+        }
+        return parsedValue;
+    }
+    if (type === 'boolean') {
+        var value = parser.readAhead(1);
+        return value === '1';
+    }
+    if (type === 'string') {
+        return parser.getByLength('"', '"', function (length) { return parser.readAhead(length); });
+    }
+    if (type === 'array-object') {
+        var pairs = parser.getByLength('{', '}', function (length) { return unserializePairs(parser, length, scope, options); });
+        var isArray = pairs.every(function (item, idx) { return helpers_1.isInteger(item.key) && idx === item.key; });
+        var result_1 = isArray ? [] : {};
+        pairs.forEach(function (_a) {
+            var key = _a.key, value = _a.value;
+            result_1[key] = value;
+        });
+        return result_1;
+    }
+    if (type === 'notserializable-class') {
+        var name = parser.getByLength('"', '"', function (length) { return parser.readAhead(length); });
+        parser.seekExpected(':');
+        var pairs = parser.getByLength('{', '}', function (length) { return unserializePairs(parser, length, scope, options); });
+        var result_2 = getClassReference(name, scope, options.strict);
+        var PREFIX_PRIVATE_1 = "\0" + name + "\0";
+        var PREFIX_PROTECTED_1 = "\0*\0";
+        pairs.forEach(function (_a) {
+            var key = _a.key, value = _a.value;
+            if (key.startsWith(PREFIX_PRIVATE_1)) {
+                // Private field
+                result_2[key.slice(PREFIX_PRIVATE_1.length)] = value;
+            }
+            else if (key.startsWith(PREFIX_PROTECTED_1)) {
+                // Protected field
+                result_2[key.slice(PREFIX_PROTECTED_1.length)] = value;
+            }
+            else {
+                result_2[key] = value;
+            }
+        });
+        return result_2;
+    }
+    if (type === 'serializable-class') {
+        var name = parser.getByLength('"', '"', function (length) { return parser.readAhead(length); });
+        parser.seekExpected(':');
+        var payload = parser.getByLength('{', '}', function (length) { return parser.readAhead(length); });
+        var result = getClassReference(name, scope, options.strict);
+        if (!(result instanceof helpers_1.__PHP_Incomplete_Class)) {
+            helpers_1.invariant(result.unserialize, "unserialize not found on class when processing '" + name + "'");
+            result.unserialize(payload);
+        }
+        return result;
+    }
+    throw new Error("Invalid type '" + type + "' encounterd while unserializing");
+}
+function unserialize(item, scope, givenOptions) {
+    if (scope === void 0) { scope = {}; }
+    if (givenOptions === void 0) { givenOptions = {}; }
+    var options = __assign({}, givenOptions);
+    if (typeof options.strict === 'undefined') {
+        options.strict = true;
+    }
+    if (typeof options.encoding === 'undefined') {
+        options.encoding = 'utf8';
+    }
+    var parser = new parser_1.default(Buffer.from(item), 0, options);
+    return unserializeItem(parser, scope, options);
+}
+exports.default = unserialize;

--- a/node_modules/php-serialize/lib/esm/helpers.js
+++ b/node_modules/php-serialize/lib/esm/helpers.js
@@ -1,0 +1,38 @@
+// eslint-disable-next-line camelcase,@typescript-eslint/class-name-casing
+var __PHP_Incomplete_Class = /** @class */ (function () {
+    function __PHP_Incomplete_Class(name) {
+        this.__PHP_Incomplete_Class_Name = name;
+    }
+    return __PHP_Incomplete_Class;
+}());
+export { __PHP_Incomplete_Class };
+export function getByteLength(contents, options) {
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.byteLength(contents, options.encoding);
+    }
+    return encodeURIComponent(contents).replace(/%[A-F\d]{2}/g, 'U').length;
+}
+// isInteger = is NOT a float but still a number
+export function isInteger(value) {
+    return typeof value === 'number' && Number.parseInt(value.toString(), 10) === value;
+}
+export function getIncompleteClass(name) {
+    return new __PHP_Incomplete_Class(name);
+}
+export function getClass(prototype) {
+    function PhpClass() {
+        // No Op
+    }
+    PhpClass.prototype = prototype;
+    return PhpClass;
+}
+/**
+ * Ensures that the given {@link value} is truthy, throws an {@link Error} otherwise.
+ * @param value the value to check to be truthy.
+ * @param message the message of the {@link Error} if the value is falsy.
+ */
+export function invariant(value, message) {
+    if (!value) {
+        throw new Error(message);
+    }
+}

--- a/node_modules/php-serialize/lib/esm/index.js
+++ b/node_modules/php-serialize/lib/esm/index.js
@@ -1,0 +1,4 @@
+import unserialize from './unserialize';
+import serialize from './serialize';
+import isSerialized from './isSerialized';
+export { serialize, unserialize, isSerialized };

--- a/node_modules/php-serialize/lib/esm/isSerialized.js
+++ b/node_modules/php-serialize/lib/esm/isSerialized.js
@@ -1,0 +1,64 @@
+/**
+ * Check value to find if it was serialized.
+ * @param { string } item - Value to check to see if was serialized.
+ * @param { boolean } strict - Whether to be strict about the end of the string. Default value: false
+ */
+export default function isSerialized(givenItem, strict) {
+    if (strict === void 0) { strict = false; }
+    if (typeof givenItem !== 'string') {
+        return false;
+    }
+    var item = givenItem.replace(/^(\s*)|(\s*)$/g, '');
+    if (item === 'N;') {
+        return true;
+    }
+    if (item.length < 4) {
+        return false;
+    }
+    if (item[1] !== ':') {
+        return false;
+    }
+    if (strict) {
+        var lastc = item.slice(-1);
+        if (lastc !== ';' && lastc !== '}') {
+            return false;
+        }
+    }
+    else {
+        var semicolon = item.indexOf(';');
+        var brace = item.indexOf('}');
+        // Either ; or } must exist.
+        if (semicolon === -1 && brace === -1) {
+            return false;
+        }
+        // But neither must be in the first X characters.
+        if (semicolon !== -1 && semicolon < 3) {
+            return false;
+        }
+        if (brace !== -1 && brace < 4) {
+            return false;
+        }
+    }
+    var token = item.slice(0, 1);
+    var end = strict ? '$' : '';
+    switch (token) {
+        case 's':
+        case 'a':
+        case 'O':
+            if (strict) {
+                if (item.substr(-2, 1) !== '"') {
+                    return false;
+                }
+            }
+            else if (item.indexOf('"') === -1) {
+                return false;
+            }
+            return item.match(new RegExp("^" + token + ":[0-9]+:", 's')) !== null;
+        case 'b':
+        case 'i':
+        case 'd':
+            return item.match(new RegExp("^" + token + ":[0-9.E+-]+;" + end)) !== null;
+        default:
+    }
+    return false;
+}

--- a/node_modules/php-serialize/lib/esm/parser.js
+++ b/node_modules/php-serialize/lib/esm/parser.js
@@ -1,0 +1,89 @@
+var __read = (this && this.__read) || function (o, n) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator];
+    if (!m) return o;
+    var i = m.call(o), r, ar = [], e;
+    try {
+        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+    }
+    catch (error) { e = { error: error }; }
+    finally {
+        try {
+            if (r && !r.done && (m = i["return"])) m.call(i);
+        }
+        finally { if (e) throw e.error; }
+    }
+    return ar;
+};
+var PARSER_TYPES = {
+    N: 'null',
+    i: 'int',
+    d: 'float',
+    b: 'boolean',
+    s: 'string',
+    a: 'array-object',
+    C: 'serializable-class',
+    O: 'notserializable-class',
+};
+var Parser = /** @class */ (function () {
+    function Parser(contents, index, options) {
+        this.contents = contents;
+        this.index = index;
+        this.options = options;
+    }
+    Parser.prototype.error = function (message) {
+        if (message === void 0) { message = 'Syntax Error'; }
+        return new Error(message + " at index " + this.index + " while unserializing payload");
+    };
+    Parser.prototype.advance = function (index) {
+        this.index += index;
+    };
+    Parser.prototype.readAhead = function (index) {
+        var contents = this.peekAhead(index);
+        this.index += index;
+        return contents;
+    };
+    Parser.prototype.readUntil = function (expected) {
+        var index = this.contents.indexOf(expected, this.index);
+        if (index === -1) {
+            throw this.error("Expected '" + expected + "'");
+        }
+        return this.readAhead(index - this.index);
+    };
+    Parser.prototype.peekAhead = function (index) {
+        return this.contents.toString(this.options.encoding, this.index, this.index + index);
+    };
+    Parser.prototype.seekExpected = function (contents) {
+        var slice = this.readAhead(contents.length);
+        if (slice !== contents) {
+            this.index -= contents.length;
+            throw this.error("Expected '" + contents + "'");
+        }
+    };
+    Parser.prototype.getType = function () {
+        var _a = __read(this.readAhead(2), 2), type = _a[0], ps = _a[1];
+        var parserType = PARSER_TYPES[type];
+        if (!parserType) {
+            throw this.error('Unknown type');
+        }
+        if (parserType === 'null' ? ps !== ';' : ps !== ':') {
+            throw this.error();
+        }
+        return parserType;
+    };
+    Parser.prototype.getLength = function () {
+        var length = Number.parseInt(this.readUntil(':'), 10);
+        if (Number.isNaN(length)) {
+            throw this.error();
+        }
+        return length;
+    };
+    Parser.prototype.getByLength = function (startSequence, endSequence, callback) {
+        var length = this.getLength();
+        this.seekExpected(":" + startSequence);
+        var result = callback(length);
+        this.seekExpected(endSequence);
+        return result;
+    };
+    return Parser;
+}());
+export default Parser;

--- a/node_modules/php-serialize/lib/esm/serialize.js
+++ b/node_modules/php-serialize/lib/esm/serialize.js
@@ -1,0 +1,83 @@
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __read = (this && this.__read) || function (o, n) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator];
+    if (!m) return o;
+    var i = m.call(o), r, ar = [], e;
+    try {
+        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+    }
+    catch (error) { e = { error: error }; }
+    finally {
+        try {
+            if (r && !r.done && (m = i["return"])) m.call(i);
+        }
+        finally { if (e) throw e.error; }
+    }
+    return ar;
+};
+import { isInteger, getByteLength, invariant } from './helpers';
+function getClassNamespace(item, scope) {
+    return (Object.keys(scope).find(function (key) { return item instanceof scope[key]; }) || item.__PHP_Incomplete_Class_Name || item.constructor.name);
+}
+function serializeObject(item, scope) {
+    var processed = Array.isArray(item)
+        ? item.map(function (value, index) { return "" + serialize(index, scope) + serialize(value, scope); })
+        : Object.keys(item).map(function (key) { return "" + serialize(key, scope) + serialize(item[key], scope); });
+    var length = processed.filter(function (entry) { return typeof entry !== 'undefined'; }).length;
+    return length + ":{" + processed.join('') + "}";
+}
+export default function serialize(item, scope, givenOptions) {
+    if (scope === void 0) { scope = {}; }
+    if (givenOptions === void 0) { givenOptions = {}; }
+    var type = typeof item;
+    var options = __assign({}, givenOptions);
+    if (typeof options.encoding === 'undefined') {
+        options.encoding = 'utf8';
+    }
+    if (item === null) {
+        return 'N;';
+    }
+    if (type === 'number' || type === 'bigint') {
+        if (typeof item === 'bigint' || isInteger(item)) {
+            return "i:" + item + ";";
+        }
+        return "d:" + item.toString().toUpperCase() + ";";
+    }
+    if (type === 'string') {
+        return "s:" + getByteLength(item, options) + ":\"" + item + "\";";
+    }
+    if (type === 'boolean') {
+        return "b:" + (item ? '1' : '0') + ";";
+    }
+    if (type !== 'object') {
+        throw new TypeError("Unexpected type '" + type + "' encountered while attempting to serialize");
+    }
+    if (Array.isArray(item) || item.constructor.name === 'Object') {
+        return "a:" + serializeObject(item, scope);
+    }
+    if (item instanceof Map) {
+        return "a:" + item.size + ":{" + Array.from(item.entries())
+            .map(function (_a) {
+            var _b = __read(_a, 2), key = _b[0], value = _b[1];
+            return "" + serialize(key, scope) + serialize(value, scope);
+        })
+            .join('') + "}";
+    }
+    var constructorName = getClassNamespace(item, scope);
+    if (typeof item.serialize === 'function') {
+        var serialized = item.serialize();
+        invariant(typeof serialized === 'string', item.constructor.name + ".serialize should return a string");
+        return "C:" + constructorName.length + ":\"" + constructorName + "\":" + getByteLength(serialized, options) + ":{" + serialized + "}";
+    }
+    return "O:" + constructorName.length + ":\"" + constructorName + "\":" + serializeObject(item, scope);
+}

--- a/node_modules/php-serialize/lib/esm/unserialize.js
+++ b/node_modules/php-serialize/lib/esm/unserialize.js
@@ -1,0 +1,125 @@
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+// eslint-disable-next-line import/no-cycle
+import Parser from './parser';
+import { isInteger, getClass, getIncompleteClass, __PHP_Incomplete_Class, invariant } from './helpers';
+function getClassReference(className, scope, strict) {
+    var container;
+    var classReference = scope[className];
+    invariant(classReference || !strict, "Class " + className + " not found in given scope");
+    if (classReference) {
+        // @ts-ignore
+        container = new (getClass(classReference.prototype))();
+    }
+    else {
+        container = getIncompleteClass(className);
+    }
+    return container;
+}
+function unserializePairs(parser, length, scope, options) {
+    var pairs = [];
+    for (var i = 0; i < length; i += 1) {
+        var key = unserializeItem(parser, scope, options);
+        parser.seekExpected(';');
+        var value = unserializeItem(parser, scope, options);
+        if (parser.peekAhead(1) === ';') {
+            parser.advance(1);
+        }
+        pairs.push({ key: key, value: value });
+    }
+    return pairs;
+}
+function unserializeItem(parser, scope, options) {
+    var type = parser.getType();
+    if (type === 'null') {
+        return null;
+    }
+    if (type === 'int' || type === 'float') {
+        var value = parser.readUntil(';');
+        var parsedValue = type === 'int' ? parseInt(value, 10) : parseFloat(value);
+        if (parsedValue.toString() !== value) {
+            if (!value.includes('.')) {
+                parsedValue = BigInt(value); // Only convert to BigInt if there's no decimal
+            }
+            else {
+                parsedValue = parseFloat(value); // Ensure floats remain as float
+            }
+        }
+        return parsedValue;
+    }
+    if (type === 'boolean') {
+        var value = parser.readAhead(1);
+        return value === '1';
+    }
+    if (type === 'string') {
+        return parser.getByLength('"', '"', function (length) { return parser.readAhead(length); });
+    }
+    if (type === 'array-object') {
+        var pairs = parser.getByLength('{', '}', function (length) { return unserializePairs(parser, length, scope, options); });
+        var isArray = pairs.every(function (item, idx) { return isInteger(item.key) && idx === item.key; });
+        var result_1 = isArray ? [] : {};
+        pairs.forEach(function (_a) {
+            var key = _a.key, value = _a.value;
+            result_1[key] = value;
+        });
+        return result_1;
+    }
+    if (type === 'notserializable-class') {
+        var name = parser.getByLength('"', '"', function (length) { return parser.readAhead(length); });
+        parser.seekExpected(':');
+        var pairs = parser.getByLength('{', '}', function (length) { return unserializePairs(parser, length, scope, options); });
+        var result_2 = getClassReference(name, scope, options.strict);
+        var PREFIX_PRIVATE_1 = "\0" + name + "\0";
+        var PREFIX_PROTECTED_1 = "\0*\0";
+        pairs.forEach(function (_a) {
+            var key = _a.key, value = _a.value;
+            if (key.startsWith(PREFIX_PRIVATE_1)) {
+                // Private field
+                result_2[key.slice(PREFIX_PRIVATE_1.length)] = value;
+            }
+            else if (key.startsWith(PREFIX_PROTECTED_1)) {
+                // Protected field
+                result_2[key.slice(PREFIX_PROTECTED_1.length)] = value;
+            }
+            else {
+                result_2[key] = value;
+            }
+        });
+        return result_2;
+    }
+    if (type === 'serializable-class') {
+        var name = parser.getByLength('"', '"', function (length) { return parser.readAhead(length); });
+        parser.seekExpected(':');
+        var payload = parser.getByLength('{', '}', function (length) { return parser.readAhead(length); });
+        var result = getClassReference(name, scope, options.strict);
+        if (!(result instanceof __PHP_Incomplete_Class)) {
+            invariant(result.unserialize, "unserialize not found on class when processing '" + name + "'");
+            result.unserialize(payload);
+        }
+        return result;
+    }
+    throw new Error("Invalid type '" + type + "' encounterd while unserializing");
+}
+function unserialize(item, scope, givenOptions) {
+    if (scope === void 0) { scope = {}; }
+    if (givenOptions === void 0) { givenOptions = {}; }
+    var options = __assign({}, givenOptions);
+    if (typeof options.strict === 'undefined') {
+        options.strict = true;
+    }
+    if (typeof options.encoding === 'undefined') {
+        options.encoding = 'utf8';
+    }
+    var parser = new Parser(Buffer.from(item), 0, options);
+    return unserializeItem(parser, scope, options);
+}
+export default unserialize;

--- a/node_modules/php-serialize/lib/typings/helpers.d.ts
+++ b/node_modules/php-serialize/lib/typings/helpers.d.ts
@@ -1,0 +1,20 @@
+/// <reference types="node" />
+export declare class __PHP_Incomplete_Class {
+    __PHP_Incomplete_Class_Name: string;
+    constructor(name: string);
+}
+export declare function getByteLength(contents: string, options: {
+    encoding: BufferEncoding;
+}): number;
+export declare function isInteger(value: any): boolean;
+export declare function getIncompleteClass(name: string): __PHP_Incomplete_Class;
+export declare function getClass(prototype: Record<string, any>): {
+    (): void;
+    prototype: Record<string, any>;
+};
+/**
+ * Ensures that the given {@link value} is truthy, throws an {@link Error} otherwise.
+ * @param value the value to check to be truthy.
+ * @param message the message of the {@link Error} if the value is falsy.
+ */
+export declare function invariant(value: any, message?: string): void;

--- a/node_modules/php-serialize/lib/typings/index.d.ts
+++ b/node_modules/php-serialize/lib/typings/index.d.ts
@@ -1,0 +1,4 @@
+import unserialize from './unserialize';
+import serialize from './serialize';
+import isSerialized from './isSerialized';
+export { serialize, unserialize, isSerialized };

--- a/node_modules/php-serialize/lib/typings/isSerialized.d.ts
+++ b/node_modules/php-serialize/lib/typings/isSerialized.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Check value to find if it was serialized.
+ * @param { string } item - Value to check to see if was serialized.
+ * @param { boolean } strict - Whether to be strict about the end of the string. Default value: false
+ */
+export default function isSerialized(givenItem: string, strict?: boolean): boolean;

--- a/node_modules/php-serialize/lib/typings/parser.d.ts
+++ b/node_modules/php-serialize/lib/typings/parser.d.ts
@@ -1,0 +1,18 @@
+/// <reference types="node" />
+import type { Options } from './unserialize';
+export declare type ParserType = 'null' | 'int' | 'float' | 'boolean' | 'string' | 'array-object' | 'serializable-class' | 'notserializable-class';
+export default class Parser {
+    index: number;
+    contents: Buffer;
+    options: Options;
+    constructor(contents: Buffer, index: number, options: Options);
+    error(message?: string): Error;
+    advance(index: number): void;
+    readAhead(index: number): string;
+    readUntil(expected: string): string;
+    peekAhead(index: number): string;
+    seekExpected(contents: string): void;
+    getType(): ParserType;
+    getLength(): number;
+    getByLength<T>(startSequence: string, endSequence: string, callback: (length: number) => T): T;
+}

--- a/node_modules/php-serialize/lib/typings/serialize.d.ts
+++ b/node_modules/php-serialize/lib/typings/serialize.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="node" />
+export default function serialize(item: any, scope?: Record<string, any>, givenOptions?: {
+    encoding?: BufferEncoding;
+}): string;

--- a/node_modules/php-serialize/lib/typings/unserialize.d.ts
+++ b/node_modules/php-serialize/lib/typings/unserialize.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="node" />
+export declare type Options = {
+    strict: boolean;
+    encoding: BufferEncoding;
+};
+declare function unserialize(item: string | Buffer, scope?: Record<string, any>, givenOptions?: Partial<Options>): any;
+export default unserialize;

--- a/node_modules/php-serialize/package.json
+++ b/node_modules/php-serialize/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "php-serialize",
+  "version": "5.1.3",
+  "description": "PHP serialize/unserialize in Javascript",
+  "main": "lib/cjs/index.js",
+  "typings": "lib/typings/index.d.ts",
+  "module": "lib/esm/index.js",
+  "scripts": {
+    "test": "ava",
+    "test:update-php-output": "php test/serialize.php > test/serialize.php.out",
+    "lint": "(tsc -p . --noEmit) && (eslint . --ext .ts) && (prettier --list-different src/*.ts)",
+    "prepare": "yarn build:clean ; yarn build:esm ; yarn build:cjs ; yarn build:typings",
+    "build:clean": "rm -rf lib",
+    "build:esm": "tsc --module es2015 --target es5 --outDir lib/esm",
+    "build:cjs": "tsc --module commonjs --target es5 --outDir lib/cjs",
+    "build:typings": "tsc --declaration --outDir lib/typings --emitDeclarationOnly"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/steelbrain/php-serialize.git"
+  },
+  "author": "steelbrain",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/steelbrain/php-serialize/issues"
+  },
+  "files": [
+    "lib/*"
+  ],
+  "homepage": "https://php-serialize.com",
+  "devDependencies": {
+    "ava": "^3.7.0",
+    "eslint-config-steelbrain": "^9.0.1",
+    "ts-node": "^8.8.2",
+    "typescript": "^3.8.3"
+  },
+  "dependencies": {},
+  "ava": {
+    "files": [
+      "test/*-test.ts"
+    ],
+    "extensions": [
+      "ts"
+    ],
+    "require": [
+      "ts-node/register/transpile-only"
+    ]
+  },
+  "engines": {
+    "node": ">= 8"
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "api_nodejs",
+  "name": "member-midone",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -11,6 +11,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "mysql2": "^3.14.1",
+        "php-serialize": "^5.1.3",
         "wordpress-hash-node": "^1.0.0"
       }
     },
@@ -683,6 +684,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/php-serialize": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/php-serialize/-/php-serialize-5.1.3.tgz",
+      "integrity": "sha512-p7zXX8xjGgddgP6byN+KmGKM0x6uoMZBRZteBa9LonqgrDV3LyMxUeGVX7RTFYwWaUAnTEsUWJfHI3N7eKvJgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "mysql2": "^3.14.1",
+    "php-serialize": "^5.1.3",
     "wordpress-hash-node": "^1.0.0"
   }
 }


### PR DESCRIPTION
- Added php-serialize as a dependency in package.json.
- Included license and README files for php-serialize.
- Implemented core serialization and unserialization logic in the library.
- Added typings for TypeScript support.
- Updated package.json with necessary scripts and metadata.